### PR TITLE
Expose electron globals in karma test environment iframe

### DIFF
--- a/runner.electron/main.js
+++ b/runner.electron/main.js
@@ -13,8 +13,17 @@ app.on('window-all-closed', function(){
 
 app.on('ready', function () {
 	mainWindow = new BrowserWindow({width:400, height:300});
-	mainWindow.loadUrl('%URL%');
 	mainWindow.on('closed', function () {
 		mainWindow =  null;
 	});
+
+  mainWindow.webContents.on('dom-ready', function() {
+    mainWindow.webContents.executeJavaScript('frame = document.getElementById("context"); \
+                                              frame.addEventListener("load", function() { \
+                                                frame.contentWindow["global"] = window; \
+                                                frame.contentWindow["process"] = window.process; \
+                                                frame.contentWindow["require"] = window.require; \
+                                              })');
+  });
+  mainWindow.loadUrl('%URL%');
 })


### PR DESCRIPTION
Expose Electron globals to karma test iframes, so require etc. are defined without a separate shim.

NB. at least with mocha, `require` seems to only be set inside the `it` block, not globally in test files.
