### PR TITLE
Update to electron>=0.35.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ Karma launcher for GitHub Electron inspired by [Karma Nodewebkit Launcher](https
 
 The easiest way is to keep `karma-electron-launcher` as a devDependency in your `package.json`.
 
+For `electron<=0.34.3`, use `karma-electron-launcher@~0.0.5`.
 
     {
       "devDependencies": {
         "karma": "~0.10",
-        "karma-electron-launcher": "~0.0.5"
+        "karma-electron-launcher": "~0.1.0"
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ncp": "^2.0.0"
   },
   "peerDependencies": {
-    "electron-prebuilt": "*",
+    "electron-prebuilt": ">=0.35.0",
     "karma": ">=0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-electron-launcher",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "A Karma Plugin. Launcher for github electron shell.",
   "main": "index.js",
   "repository": {

--- a/runner.electron/main.js
+++ b/runner.electron/main.js
@@ -1,7 +1,5 @@
-var app = require('app');
-var BrowserWindow = require('browser-window');
-
-require('crash-reporter').start();
+var app = require('electron').app;
+var BrowserWindow = require('electron').BrowserWindow;
 
 var mainWindow = null;
 var opts = %OPTS%;
@@ -18,7 +16,7 @@ app.on('window-all-closed', function(){
 
 app.on('ready', function () {
 	mainWindow = new BrowserWindow(opts);
-	mainWindow.loadUrl('%URL%');
+	mainWindow.loadURL('%URL%');
 	mainWindow.on('closed', function () {
 		mainWindow = null;
 	});


### PR DESCRIPTION
- Removed usage of deprecated Electron APIs
- Removed the crash-handler because it is not necessary and only prints annoying debug messages which causes problems on Windows when trying to stop Karma with Ctrl+C
- Bumped version to 0.1.0 because of breaking changes (added notice to Readme)

Please merge it. These debug messages are really enoying :confused: 
