### PR TITLE
Switch to electron package (closes #13)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require('path');
 var ncp = require('ncp').ncp;
 var async = require('async');
 var merge = require('merge');
-var electronPath = require ('electron-prebuilt');
+var electronPath = require ('electron');
 
 var defaultElectron = {
   width  : 400,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ncp": "^2.0.0"
   },
   "peerDependencies": {
-    "electron-prebuilt": ">=0.35.0",
+    "electron": ">=1.3.1",
     "karma": ">=0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-electron-launcher",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A Karma Plugin. Launcher for github electron shell.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Package `electron-prebuilt` is deprecated and ends its life in the end of 2016 as described in [Electron blog post](http://electron.atom.io/blog/2016/08/16/npm-install-electron).

This PR switches to `electron` package.