### PR TITLE
Allow passing flags to electron binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ module.exports = function(config) {
 
 ## Configuring custom launchers
 
-If you need to configure custom launchers differently to each other, then define `electronOpts` within the custom launcher config. This will be merged with `electronOpts` in the parent config object and override any properties already set.
+If you need to configure custom launchers differently to each other, then define `electronOpts` within the custom launcher config. This will be merged with `electronOpts` in the parent config object and override any properties already set. Custom launchers also allow you to provide additional flags to the electron executable.
 
 ```javascript
 // karma.conf.js
@@ -133,6 +133,7 @@ module.exports = function(config) {
         electronOpts: {
           title: 'my custom title',
         },
+        flags: ['--no-sandbox'],
       },
     },
   });

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var ElectronBrowser = function(baseBrowserDecorator, args, electronOpts) {
   baseBrowserDecorator(this);
 
   var customOptions = args.options || {};
+  var customFlags = args.flags || [];
   var browserOptions = merge(true, defaultElectron, electronOpts || {}, args.electronOpts || {});
   var searchPaths = (args.paths || ['node_modules']).map(function(searchPath) {
     return path.join(process.cwd(), searchPath);
@@ -50,7 +51,7 @@ var ElectronBrowser = function(baseBrowserDecorator, args, electronOpts) {
       }],
       'exec': ['main.js:write', 'package.json:write', function(callback) {
         process.env.NODE_PATH = searchPaths.join(path.delimiter);
-        self._execCommand(self._getCommand(), [STATIC_PATH]);
+        self._execCommand(self._getCommand(), customFlags.concat(STATIC_PATH));
       }]
     });
   };


### PR DESCRIPTION
Hi!

For running my karma tests in a headless Docker container I needed a way to run the Electron executable with the `--no-sandbox` flag. The Chrome launcher for Karma allows to provide additional flags to the binary, which solves exactly that problem. This change allows to pass arbitrary additional flags to the electron binary with the same configuration option that karma-chrome-launcher uses. 

Could you consider to merge this and update the version you published on npm? If you see any problems with this change or have further requirements, I'm happy to make changes.

Greetings!
Fabian